### PR TITLE
Fix: artifactObj is now typed. Docs explain what artifact to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ cp .env.example .env
 
 ```typescript
 import { AztecScanClient } from "aztec-scan-sdk";
+// Use the unprocessed json object from `aztec compile` (target/) — NOT aztec.js helpers like loadContractArtifact() 
+// (converts bytecode base64 → buffer, this breaks verification).
+import artifactJson from "pathToContractFolder/target/ContractName.json" with {type: "json"}
 
 // Uses env vars or defaults to devnet
 const client = new AztecScanClient();
@@ -63,7 +66,7 @@ const client = new AztecScanClient({
 const artifactResult = await client.verifyArtifact(
   contractClassId,
   1, // version
-  artifactJson,
+  artifactJson as NoirCompiledContract,
 );
 
 // Verify a contract instance deployment
@@ -74,7 +77,7 @@ const instanceResult = await client.verifyInstance(
     deployer,          // 66 chars: "0x" + 64 hex
     salt,              // 66 chars: "0x" + 64 hex
     constructorArgs: ["arg1", "arg2"],
-    artifactObj: artifactJson, // optional if already verified
+    artifactObj: artifactJson as NoirCompiledContract, // optional if already verified
   },
   {
     // optional deployer metadata
@@ -101,6 +104,9 @@ If you're using the Aztec SDK to deploy contracts, `fromContractInstance` elimin
 ```typescript
 import { AztecScanClient, fromContractInstance } from "aztec-scan-sdk";
 import { TokenContract } from "@aztec/noir-contracts.js/Token";
+// Use the unprocessed json object from `aztec compile` (target/) — NOT aztec.js helpers like loadContractArtifact() 
+// (converts bytecode base64 → buffer, this breaks verification).
+import tokenArtifact from "@aztec/noir-contracts.js/artifacts/token_contract-Token.json" with { type: "json" }
 
 // Deploy the contract
 const { receipt: { contract, instance } } = await TokenContract.deploy(
@@ -117,8 +123,8 @@ const { address, contractClassId, verifyInstanceArgs } = fromContractInstance(in
 
 // Verify
 const client = new AztecScanClient();
-await client.verifyArtifact(contractClassId, instance.version, tokenArtifact);
-await client.verifyInstance(address, { ...verifyInstanceArgs, artifactObj: tokenArtifact });
+await client.verifyArtifact(contractClassId, instance.version, tokenArtifact as NoirCompiledContract);
+await client.verifyInstance(address, { ...verifyInstanceArgs, artifactObj: tokenArtifact as NoirCompiledContract });
 ```
 
 The helper handles:

--- a/scripts/deploy-and-verify.ts
+++ b/scripts/deploy-and-verify.ts
@@ -40,6 +40,7 @@ import { TokenContract } from "@aztec/noir-contracts.js/Token";
 // SDK imports
 import { AztecScanClient, fromContractInstance } from "../src/index.js";
 import type { DeployerMetadata } from "../src/types.js";
+import { NoirCompiledContract } from "@aztec/stdlib/noir";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 dotenv.config({ path: join(__dirname, "../.env") });
@@ -197,7 +198,7 @@ async function main() {
     contractAddress,
     {
       ...verifyInstanceArgs,
-      artifactObj: tokenArtifact,
+      artifactObj: tokenArtifact as NoirCompiledContract,
     },
     deployerMetadata,
   );

--- a/src/api-utils.ts
+++ b/src/api-utils.ts
@@ -8,6 +8,7 @@
  * - No emojis in log output — plain, parseable text
  */
 
+import { NoirCompiledContract } from "@aztec/stdlib/noir";
 import type { AztecScanConfig } from "./config.js";
 import type {
   ApiResponse,
@@ -50,9 +51,12 @@ export function generateVerifyInstanceUrl(
  *
  * Handles both `{ default: artifact }` module-style and plain artifact objects,
  * matching the pattern in @chicmoz-pkg/contract-verification.
+ * 
+ * @notice `artifactObj` requires to be the unprocessed json object from `aztec compile` (target/) — NOT from aztec.js helpers like loadContractArtifact()  
+ * (converts bytecode base64 → buffer, this breaks verification).
  */
 export function generateVerifyArtifactPayload(
-  artifactObj: Record<string, unknown>,
+  artifactObj: NoirCompiledContract,
 ): VerifyArtifactPayload {
   const artifact =
     "default" in artifactObj && typeof artifactObj.default === "object"

--- a/src/aztec-helpers.ts
+++ b/src/aztec-helpers.ts
@@ -7,6 +7,7 @@
 
 import type { ContractInstanceWithAddress } from "@aztec/aztec.js/contracts";
 import type { VerifyInstanceArgs } from "./types.js";
+import { NoirCompiledContract } from "@aztec/stdlib/noir";
 
 /**
  * Options for `fromContractInstance`.
@@ -15,7 +16,7 @@ export interface FromContractInstanceOptions {
   /** Constructor arguments as they were passed to the deploy call. Values are stringified automatically. */
   constructorArgs?: unknown[];
   /** Optional artifact object to include for combined artifact+instance verification. */
-  artifactObj?: Record<string, unknown>;
+  artifactObj?: NoirCompiledContract;
 }
 
 /**
@@ -38,6 +39,9 @@ export interface FromContractInstanceResult {
  * This extracts and stringifies `salt`, `deployer`, `publicKeysString`,
  * `constructorArgs`, and the contract `address` / `contractClassId`.
  *
+ * @notice `FromContractInstanceOptions` requires the artifactObj to be the unprocessed json object from `aztec compile` (target/) — NOT aztec.js helpers like loadContractArtifact() 
+ * (converts bytecode base64 → buffer, this breaks verification).
+ * 
  * @example
  * ```ts
  * const { contract, instance } = await TokenContract.deploy(wallet, admin, name, symbol, decimals)

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import type {
   DeployerMetadata,
   VerifyInstanceArgs,
 } from "./types.js";
+import { NoirCompiledContract } from "@aztec/stdlib/noir";
 
 // ── Re-exports ──────────────────────────────────────────────────────
 
@@ -64,12 +65,14 @@ export class AztecScanClient {
   /**
    * Verify a contract artifact (contract class).
    *
+   * @notice `artifactObj` requires to be the unprocessed json object from `aztec compile` (target/) — NOT from aztec.js helpers like loadContractArtifact() 
+   * (converts bytecode base64 → buffer, this breaks verification).
    * @returns API response. Status 200 = already verified, 201 = newly verified.
    */
   async verifyArtifact(
     contractClassId: string,
     version: number,
-    artifactObj: Record<string, unknown>,
+    artifactObj: NoirCompiledContract,
   ): Promise<ApiResponse> {
     const url = generateVerifyArtifactUrl(this.config, contractClassId, version);
     const payload = generateVerifyArtifactPayload(artifactObj);

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@
  * See: chicmoz/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
  */
 
+import { NoirCompiledContract } from "@aztec/stdlib/noir";
+
 // ── Artifact verification ───────────────────────────────────────────
 
 /** Payload for POST /l2/contract-classes/:classId/versions/:version */
@@ -72,7 +74,7 @@ export interface VerifyInstanceArgs {
   deployer: string;
   salt: string;
   constructorArgs: string[];
-  artifactObj?: Record<string, unknown>;
+  artifactObj?: NoirCompiledContract;
 }
 
 // ── API response types ──────────────────────────────────────────────


### PR DESCRIPTION
fixes #6 

Typing: The artifactObj is now typed with `NoirCompiledContract` to resolve the ambiguity. 
Doc: README.md and AGENTS.md explain what artifact to use  now